### PR TITLE
Update compile_and_run.sh

### DIFF
--- a/compile_and_run.sh
+++ b/compile_and_run.sh
@@ -3,7 +3,7 @@
 mvn package
 
 # copy over new jmeter extension jar
-cp target/surometer-1.1-SNAPSHOT-jar-with-dependencies.jar /Applications/apache-jmeter-2.11/lib/ext/
+cp target/surometer-1.2-SNAPSHOT-jar-with-dependencies.jar /Applications/apache-jmeter-2.11/lib/ext/
 
 # get pid of any running jmeter
 jmeter_pid=$(ps -ef|grep ApacheJMeter|awk '/java/{print $2}')


### PR DESCRIPTION
Current compile is versioned at 1.2 [surometer-1.1-SNAPSHOT-jar-with-dependencies.jar] - this change updates the compile_and_run script to match, however, it does not account for the current [2.12] version of JMeter.